### PR TITLE
Deleting gpds in cluster-cleanup

### DIFF
--- a/stages/5-cluster-cleanup/cluster-cleanup
+++ b/stages/5-cluster-cleanup/cluster-cleanup
@@ -14,6 +14,9 @@ git clone https://github.com/mayadata-io/litmus.git
 cd litmus/k8s/gcp/k8s-installer/
 echo "CLEANUP ------------------------------------------------------------------------"
 
+# Fetching cluster name
+cluster_name=$(cat ~/logs/clusters)
+
 # Delete k8s cluster
 ansible-playbook delete-k8s-cluster.yml
 
@@ -26,3 +29,7 @@ gcloud compute firewall-rules delete $FIREWALL_VPC
 
 # Delete VPC
 ansible-playbook delete-vpc.yml --extra-vars "project=openebs-ci"
+
+# Delete google persistent disks created in the pipeline
+disks=$(gcloud compute disks list | awk '{print $1}'  | grep $cluster_name ) 
+for disk in $disks; do gcloud compute disks delete $disk -q; done


### PR DESCRIPTION
Deleting the google persistent disks created in the pipeline at the `cleanup-cluster` stage by filtering the disks name using cluster-name and then deleting the  disks



@harshshekhar15 @prabhatkumarthakur 