### PR TITLE
Director deploy typo

### DIFF
--- a/stages/2-provider-infra-setup/infra-setup
+++ b/stages/2-provider-infra-setup/infra-setup
@@ -10,7 +10,7 @@ cp  .kube/config ~/.kube/config
 
 kubectl get po
 
-URL=http://$(kubectl get node -o wide | awk {'print $7'} | head -n 4 | tail -n 1):30380
+URL=$(kubectl get node -o wide | awk {'print $7'} | head -n 4 | tail -n 1):30380
 
 echo "This is DOP $URL" 
 


### PR DESCRIPTION
We dont need to append `http://` in the url for values.yml. so removing that in this PR

@harshshekhar15 