### PR TITLE
(WIP)Included python script to update readme for alertstore check

### DIFF
--- a/stages/3-director-sanity-check/alertstore-check
+++ b/stages/3-director-sanity-check/alertstore-check
@@ -44,6 +44,10 @@ kubectl get po
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 echo $testResult
 
+if [[ $branch_name == "master" ]]; then
+   python3 utils/result_update.py --job_id $job_id --stage $stage --test_desc "$test_desc" --test_result $testResult --time_stamp "$current_time" --token $gittoken --test_name $test_name
+fi
+
 if [ "$testResult" != Pass ]; then 
 exit 1; 
 fi


### PR DESCRIPTION
- Included python script in alertstore-check job file 
- This python script will update the readme of the corresponding job whenever the pipeline in 
    triggered
-  Fetching job-id and github token from pipeline to update the table and passing these variables to python script
- Adding stage and test description in test file so that the values can be passed to python script and readme.md can be updated with proper information

Solves: [191](https://github.com/mayadata-io/oep/issues/191)


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>