### PR TITLE
[Openebs-Install]: Modified test job script to run pipeline jobs in sequence

### DIFF
--- a/stages/9-openebs-install-check/openebs-control-plane-test
+++ b/stages/9-openebs-install-check/openebs-control-plane-test
@@ -13,6 +13,13 @@ cp  $path/.gcp/config ~/.kube/config
 
 kubectl get po -n openebs
 
+####################################
+##  Sequencing and Running test   ##
+####################################
+
+bash utils/pooling jobname:openebs-install-check
+bash utils/e2e-cr jobname:openebs-control-plane-test jobphase:Running
+
 # Cloning oep-e2e repository which contains all the test scripts
 git clone https://$username:$password@github.com/mayadata-io/oep-e2e.git
 cd oep-e2e
@@ -38,5 +45,7 @@ testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-column
 echo $testResult
 if [ "$testResult" != Pass ]; then 
 exit 1; 
-fi 
+else
+    bash utils/e2e-cr jobname:openebs-control-plane-test jobphase:Completed
+fi
 

--- a/stages/9-openebs-install-check/openebs-data-plane-test
+++ b/stages/9-openebs-install-check/openebs-data-plane-test
@@ -13,6 +13,13 @@ cp  $path/.gcp/config ~/.kube/config
 
 kubectl get po -n openebs
 
+####################################
+##  Sequencing and Running test   ##
+####################################
+
+bash utils/pooling jobname:openebs-control-plane-test
+bash utils/e2e-cr jobname:openebs-data-plane-test jobphase:Running
+
 # Cloning oep-e2e repository which contains all the test scripts
 git clone https://$username:$password@github.com/mayadata-io/oep-e2e.git
 cd oep-e2e
@@ -38,4 +45,6 @@ testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-column
 echo $testResult
 if [ "$testResult" != Pass ]; then 
 exit 1; 
+else
+    bash utils/e2e-cr jobname:openebs-data-plane-test jobphase:Completed
 fi 

--- a/stages/9-openebs-install-check/openebs-install-check
+++ b/stages/9-openebs-install-check/openebs-install-check
@@ -13,6 +13,17 @@ cp  $path/.gcp/config ~/.kube/config
 
 kubectl get po -n openebs
 
+####################################
+##  Sequencing and Running test   ##
+####################################
+
+bash utils/e2e-cr jobname:openebs-install-check jobphase:Waiting
+bash utils/e2e-cr jobname:openebs-install-check jobphase:Running
+bash utils/e2e-cr jobname:openebs-control-plane-test jobphase:Waiting
+bash utils/e2e-cr jobname:openebs-data-plane-test jobphase:Waiting
+bash utils/e2e-cr jobname:openebs-reinstallation-test jobphase:Waiting
+bash utils/e2e-cr jobname:openebs-resource-limit-installation jobphase:Waiting
+
 # Cloning oep-e2e repository which contains all the test scripts
 git clone https://$username:$password@github.com/mayadata-io/oep-e2e.git
 cd oep-e2e
@@ -44,4 +55,6 @@ echo $testResult
 if [ "$testResult" != Pass ]
 then 
     exit 1;
-fi
+else
+    bash utils/e2e-cr jobname:openebs-install-check jobphase:Completed
+fi 

--- a/stages/9-openebs-install-check/openebs-reinstallation-test
+++ b/stages/9-openebs-install-check/openebs-reinstallation-test
@@ -13,6 +13,14 @@ cp  $path/.gcp/config ~/.kube/config
 
 kubectl get po -n openebs
 
+####################################
+##  Sequencing and Running test   ##
+####################################
+
+bash utils/pooling jobname:openebs-data-plane-test
+bash utils/e2e-cr jobname:openebs-reinstallation-test jobphase:Running
+
+
 # Cloning oep-e2e repository which contains all the test scripts
 git clone https://$username:$password@github.com/mayadata-io/oep-e2e.git
 cd oep-e2e
@@ -38,4 +46,6 @@ testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-column
 echo $testResult
 if [ "$testResult" != Pass ]; then 
 exit 1; 
+else
+    bash utils/e2e-cr jobname:openebs-reinstallation-test jobphase:Completed
 fi 

--- a/stages/9-openebs-install-check/openebs-resource-limit-installation
+++ b/stages/9-openebs-install-check/openebs-resource-limit-installation
@@ -11,13 +11,17 @@ path=$(pwd)
 mkdir ~/.kube
 cp  $path/.gcp/config ~/.kube/config
 
+####################################
+##  Sequencing and Running test   ##
+####################################
+
+bash utils/pooling jobname:openebs-reinstallation-test
+bash utils/e2e-cr jobname:openebs-resource-limit-installation jobphase:Running
+
 # Cloning oep-e2e repository which contains all the test scripts
 git clone https://$username:$password@github.com/mayadata-io/oep-e2e.git
 cd oep-e2e
 
-####################################
-##  Sequencing and Running test   ##
-####################################
 
 kubectl create -f litmus/director/tcid-iuoi14-openebs-resource-limit-installation/run_litmus_test.yml
 kubectl get pods -n litmus
@@ -42,4 +46,6 @@ echo $testResult
 if [ "$testResult" != Pass ]
 then 
     exit 1;
-fi
+else
+    bash utils/e2e-cr jobname:openebs-resource-limit-installation jobphase:Completed
+fi 


### PR DESCRIPTION
- In pipeline all the jobs are running parallel and the role of each job is to install openebs.
- All the jobs are installing openebs at the same time and it is not possible to install multiple openebs into the same cluster.
- So this PR will execute jobs in sequence and after each job clean-up step is there which will remove openebs.

**Sequence of jobs:**
    1  - ` openebs-install-check`
    2  -  `openebs-control-plane-test`
    3  -  ` openebs-data-plane-test`
    4 -   `openens-reinstallation`
    5 -  `openebs-resource-limit`

This Pr Fixes issue : https://github.com/mayadata-io/oep-e2e/issues/267

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>