### PR TITLE
adding missing node-selector

### DIFF
--- a/stages/2-provider-infra-setup/infra-setup
+++ b/stages/2-provider-infra-setup/infra-setup
@@ -83,6 +83,7 @@ kubectl apply -f oep/litmus/prerequisite/docker-secret.yml -n litmus
 ## Add label to node
 node_name=$(kubectl get node | awk {'print $1'} | head -n 4 | tail -n 1)
 kubectl label nodes $node_name kubernetes.io/arch="amd64"
+kubectl label nodes $node_name kubernetes.io/os=linux
 ## Installing heapster components on the cluster for node monitoring
 git clone https://github.com/kubernetes-sigs/metrics-server.git
 sed -i -e '/args:/ a\          - --kubelet-insecure-tls' metrics-server/deploy/kubernetes/metrics-server-deployment.yaml


### PR DESCRIPTION
This PR intends to do the following:
- Add label - `kubernetes.io/os: linux` to nodes to be used by metrics-server.

Signed-off-by: harshita-sharma011 <harshita.sharma@mayadata.io>